### PR TITLE
Requerimiento 4 sprint 2

### DIFF
--- a/internal/handler/product.go
+++ b/internal/handler/product.go
@@ -5,11 +5,12 @@ import (
 	"app/pkg"
 	"app/pkg/models"
 	"errors"
+	"net/http"
+	"strconv"
+
 	"github.com/bootcamp-go/web/request"
 	"github.com/bootcamp-go/web/response"
 	"github.com/go-chi/chi/v5"
-	"net/http"
-	"strconv"
 )
 
 func NewProductDefault(sv service.IProductService) *ProductDefault {
@@ -151,6 +152,11 @@ func (d ProductDefault) ReportRecords() http.HandlerFunc {
 		result, errResult := d.sv.GetProductRecords(id)
 		if errResult != nil {
 			response.Error(writer, pkg.ServiceErrors[pkg.ErrInternalServer].ResponseCode, errResult.Error())
+			return
+		}
+
+		if result == nil {
+			response.Error(writer, pkg.ServiceErrors[pkg.ErrNotFound].ResponseCode, pkg.ServiceErrors[pkg.ErrNotFound].Error())
 			return
 		}
 

--- a/internal/repository/product_map.go
+++ b/internal/repository/product_map.go
@@ -4,8 +4,9 @@ import (
 	"app/pkg"
 	"app/pkg/models"
 	"database/sql"
-	"github.com/go-sql-driver/mysql"
 	"strings"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 type ProductSql struct {
@@ -229,7 +230,9 @@ func (p ProductSql) GetProductRecords(id *int) ([]models.ProductRecordResponse, 
 	}
 	defer rows.Close()
 
+	hasRecords := false
 	for rows.Next() {
+		hasRecords = true
 		var prodReport models.ProductRecordResponse
 		err := rows.Scan(
 			&prodReport.ProductId,
@@ -242,8 +245,23 @@ func (p ProductSql) GetProductRecords(id *int) ([]models.ProductRecordResponse, 
 		productRecordists = append(productRecordists, prodReport)
 	}
 
-	return productRecordists, nil
+	if !hasRecords && id != nil {
+		prod, err := p.GetById(*id)
+		if err == nil && prod != nil {
+			description := ""
+			if prod.Description != nil {
+				description = *prod.Description
+			}
+			prodReport := models.ProductRecordResponse{
+				ProductId:    prod.ID,
+				Description:  description,
+				RecordsCount: 0,
+			}
+			productRecordists = append(productRecordists, prodReport)
+		}
+	}
 
+	return productRecordists, nil
 }
 
 func errorCreateUpdate(err error) pkg.ServiceError {


### PR DESCRIPTION
Product ReportRecords API Enhancement
Modified GetProductRecords to return product information with records_count: 0 when the product exists but has no associated records. If the product does not exist, the handler now returns a 404. This ensures a consistent API response structure and improves the client experience.