### PR TITLE
changed carry handler error from http500 to http409

### DIFF
--- a/internal/handler/carry.go
+++ b/internal/handler/carry.go
@@ -100,7 +100,7 @@ func (h *CarryDefault) Create() http.HandlerFunc {
 		carry, err = h.sv.Create(carry)
 
 		if err != nil {
-			svcErr := pkg.ServiceErrors[pkg.ErrInternalServer]
+			svcErr := pkg.ServiceErrors[pkg.ErrConflict]
 			svcErr.InternalError = fmt.Errorf(err.Error())
 			response.Error(w, svcErr.ResponseCode, svcErr.Error())
 			return


### PR DESCRIPTION
Modified error code returned in handler/carry.go

from:
svcErr := pkg.ServiceErrors[pkg.ErrInternalServer] //http 500

to:
svcErr := pkg.ServiceErrors[pkg.ErrConflict] //http 409